### PR TITLE
Relicensing incub8 contributions under the Apache License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2017 mizool
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+Mizool
+Copyright 2017 incub8 Software Labs GmbH.
+
+JCache CDI Extensions
+Copyright 2001-2015 The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,8 @@
     <version>0.1-SNAPSHOT</version>
     <licenses>
         <license>
-            <name>MIT</name>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
 

--- a/src/main/java/com/github/mizool/Optionals.java
+++ b/src/main/java/com/github/mizool/Optionals.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool;
 
 import lombok.AccessLevel;

--- a/src/main/java/com/github/mizool/aws/dynamodb/DynamoDbMapperProducer.java
+++ b/src/main/java/com/github/mizool/aws/dynamodb/DynamoDbMapperProducer.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.aws.dynamodb;
 
 import javax.enterprise.inject.Produces;

--- a/src/main/java/com/github/mizool/aws/dynamodb/ZonedDateTimeConverter.java
+++ b/src/main/java/com/github/mizool/aws/dynamodb/ZonedDateTimeConverter.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.aws.dynamodb;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCacheInterceptor.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCacheInterceptor.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCacheLookupUtil.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCacheLookupUtil.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCachePutInterceptor.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCachePutInterceptor.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCacheRemoveAllInterceptor.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCacheRemoveAllInterceptor.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCacheRemoveEntryInterceptor.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCacheRemoveEntryInterceptor.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCacheResultInterceptor.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractCacheResultInterceptor.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractInternalCacheInvocationContext.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractInternalCacheInvocationContext.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractInternalCacheKeyInvocationContext.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractInternalCacheKeyInvocationContext.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractKeyedCacheInterceptor.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractKeyedCacheInterceptor.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractStaticCacheInvocationContext.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/AbstractStaticCacheInvocationContext.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheContextSource.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheContextSource.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheInvocationParameterImpl.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheInvocationParameterImpl.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheMethodDetailsImpl.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheMethodDetailsImpl.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheParameterDetails.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheParameterDetails.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CachePutMethodDetails.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CachePutMethodDetails.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheRemoveAllMethodDetails.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheRemoveAllMethodDetails.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheRemoveEntryMethodDetails.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheRemoveEntryMethodDetails.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheResultMethodDetails.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/CacheResultMethodDetails.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/ClassFilter.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/ClassFilter.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/DefaultCacheKeyGenerator.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/DefaultCacheKeyGenerator.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/DefaultCacheResolver.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/DefaultCacheResolver.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/DefaultCacheResolverFactory.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/DefaultCacheResolverFactory.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/DefaultGeneratedCacheKey.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/DefaultGeneratedCacheKey.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/InterceptorType.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/InterceptorType.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/InternalCacheInvocationContext.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/InternalCacheInvocationContext.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/InternalCacheKeyInvocationContext.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/InternalCacheKeyInvocationContext.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/StaticCacheInvocationContext.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/StaticCacheInvocationContext.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/StaticCacheKeyInvocationContext.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/StaticCacheKeyInvocationContext.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/common/StaticCacheResultInvocationContext.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/common/StaticCacheResultInvocationContext.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/util/BeanManagerUtil.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/util/BeanManagerUtil.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CacheLookupUtil.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CacheLookupUtil.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CachePutInterceptor.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CachePutInterceptor.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CacheRemoveAllInterceptor.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CacheRemoveAllInterceptor.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CacheRemoveEntryInterceptor.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CacheRemoveEntryInterceptor.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CacheResultInterceptor.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CacheResultInterceptor.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CdiCacheInvocationContextImpl.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CdiCacheInvocationContextImpl.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CdiCacheKeyInvocationContextImpl.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/util/CdiCacheKeyInvocationContextImpl.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/annotations/util/InterceptorExtension.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/annotations/util/InterceptorExtension.java
@@ -1,6 +1,7 @@
 /**
  *  Copyright 2011-2013 Terracotta, Inc.
  *  Copyright 2011-2013 Oracle America Incorporated
+ *  Copyright 2015-2017 incub8 Software Labs GmbH
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/mizool/cdi/jcache/extension/AnyLiteral.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/extension/AnyLiteral.java
@@ -15,6 +15,8 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ *  Modified by incub8 Software Labs GmbH
  */
 package com.github.mizool.cdi.jcache.extension;
 

--- a/src/main/java/com/github/mizool/cdi/jcache/extension/CacheManagerBean.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/extension/CacheManagerBean.java
@@ -15,6 +15,8 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ *  Modified by incub8 Software Labs GmbH
  */
 package com.github.mizool.cdi.jcache.extension;
 

--- a/src/main/java/com/github/mizool/cdi/jcache/extension/CacheProviderBean.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/extension/CacheProviderBean.java
@@ -15,6 +15,8 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ *  Modified by incub8 Software Labs GmbH
  */
 package com.github.mizool.cdi.jcache.extension;
 

--- a/src/main/java/com/github/mizool/cdi/jcache/extension/DefaultLiteral.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/extension/DefaultLiteral.java
@@ -15,6 +15,8 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ *  Modified by incub8 Software Labs GmbH
  */
 package com.github.mizool.cdi.jcache.extension;
 

--- a/src/main/java/com/github/mizool/cdi/jcache/extension/ExtraJCacheExtension.java
+++ b/src/main/java/com/github/mizool/cdi/jcache/extension/ExtraJCacheExtension.java
@@ -15,6 +15,8 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ *  Modified by incub8 Software Labs GmbH
  */
 package com.github.mizool.cdi.jcache.extension;
 

--- a/src/main/java/com/github/mizool/converter/JavaUtilDateConverter.java
+++ b/src/main/java/com/github/mizool/converter/JavaUtilDateConverter.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.converter;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/github/mizool/exception/ArgumentNullException.java
+++ b/src/main/java/com/github/mizool/exception/ArgumentNullException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 /**

--- a/src/main/java/com/github/mizool/exception/AuthenticationMissingException.java
+++ b/src/main/java/com/github/mizool/exception/AuthenticationMissingException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 public class AuthenticationMissingException extends RuntimeException

--- a/src/main/java/com/github/mizool/exception/AuthenticationRejectedException.java
+++ b/src/main/java/com/github/mizool/exception/AuthenticationRejectedException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 public class AuthenticationRejectedException extends RuntimeException

--- a/src/main/java/com/github/mizool/exception/BadRequestException.java
+++ b/src/main/java/com/github/mizool/exception/BadRequestException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 /**

--- a/src/main/java/com/github/mizool/exception/CodeInconsistencyException.java
+++ b/src/main/java/com/github/mizool/exception/CodeInconsistencyException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 /**

--- a/src/main/java/com/github/mizool/exception/ConfigurationException.java
+++ b/src/main/java/com/github/mizool/exception/ConfigurationException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 /**

--- a/src/main/java/com/github/mizool/exception/ConflictingEntityException.java
+++ b/src/main/java/com/github/mizool/exception/ConflictingEntityException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 /**

--- a/src/main/java/com/github/mizool/exception/DataInconsistencyException.java
+++ b/src/main/java/com/github/mizool/exception/DataInconsistencyException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 /**

--- a/src/main/java/com/github/mizool/exception/MethodNotAllowedException.java
+++ b/src/main/java/com/github/mizool/exception/MethodNotAllowedException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 public class MethodNotAllowedException extends RuntimeException

--- a/src/main/java/com/github/mizool/exception/NotYetImplementedException.java
+++ b/src/main/java/com/github/mizool/exception/NotYetImplementedException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 /**

--- a/src/main/java/com/github/mizool/exception/ObjectNotFoundException.java
+++ b/src/main/java/com/github/mizool/exception/ObjectNotFoundException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 /**

--- a/src/main/java/com/github/mizool/exception/PermissionDeniedException.java
+++ b/src/main/java/com/github/mizool/exception/PermissionDeniedException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 public class PermissionDeniedException extends RuntimeException

--- a/src/main/java/com/github/mizool/exception/StoreLayerException.java
+++ b/src/main/java/com/github/mizool/exception/StoreLayerException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 public class StoreLayerException extends RuntimeException

--- a/src/main/java/com/github/mizool/exception/UnprocessableEntityException.java
+++ b/src/main/java/com/github/mizool/exception/UnprocessableEntityException.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.exception;
 
 /**

--- a/src/main/java/com/github/mizool/jackson/CustomObjectMapperProvider.java
+++ b/src/main/java/com/github/mizool/jackson/CustomObjectMapperProvider.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.jackson;
 
 import javax.ws.rs.ext.ContextResolver;

--- a/src/main/java/com/github/mizool/jackson/LocalDateTimeDeserializer.java
+++ b/src/main/java/com/github/mizool/jackson/LocalDateTimeDeserializer.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.jackson;
 
 import java.io.IOException;

--- a/src/main/java/com/github/mizool/jackson/LocalDateTimeModule.java
+++ b/src/main/java/com/github/mizool/jackson/LocalDateTimeModule.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.jackson;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/github/mizool/jackson/LocalDateTimeSerializer.java
+++ b/src/main/java/com/github/mizool/jackson/LocalDateTimeSerializer.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.jackson;
 
 import java.io.IOException;

--- a/src/main/java/com/github/mizool/jackson/ZonedDateTimeDeserializer.java
+++ b/src/main/java/com/github/mizool/jackson/ZonedDateTimeDeserializer.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.jackson;
 
 import java.io.IOException;

--- a/src/main/java/com/github/mizool/jackson/ZonedDateTimeModule.java
+++ b/src/main/java/com/github/mizool/jackson/ZonedDateTimeModule.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.jackson;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/com/github/mizool/jackson/ZonedDateTimeSerializer.java
+++ b/src/main/java/com/github/mizool/jackson/ZonedDateTimeSerializer.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.jackson;
 
 import java.io.IOException;

--- a/src/main/java/com/github/mizool/shiro/AbstractEnvironmentLoaderListener.java
+++ b/src/main/java/com/github/mizool/shiro/AbstractEnvironmentLoaderListener.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.shiro;
 
 import java.util.List;

--- a/src/main/java/com/github/mizool/validation/AbstractTypeMappingValidator.java
+++ b/src/main/java/com/github/mizool/validation/AbstractTypeMappingValidator.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.validation;
 
 import java.lang.annotation.Annotation;

--- a/src/main/java/com/github/mizool/validation/CheckEnumValue.java
+++ b/src/main/java/com/github/mizool/validation/CheckEnumValue.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.validation;
 
 import javax.validation.ConstraintValidatorContext;

--- a/src/main/java/com/github/mizool/validation/CheckNotEmpty.java
+++ b/src/main/java/com/github/mizool/validation/CheckNotEmpty.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.validation;
 
 import javax.validation.ConstraintValidator;

--- a/src/main/java/com/github/mizool/validation/CheckUuidValue.java
+++ b/src/main/java/com/github/mizool/validation/CheckUuidValue.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.validation;
 
 import java.util.UUID;

--- a/src/main/java/com/github/mizool/validation/EnumValue.java
+++ b/src/main/java/com/github/mizool/validation/EnumValue.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.validation;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;

--- a/src/main/java/com/github/mizool/validation/NotEmpty.java
+++ b/src/main/java/com/github/mizool/validation/NotEmpty.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.validation;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;

--- a/src/main/java/com/github/mizool/validation/UuidValue.java
+++ b/src/main/java/com/github/mizool/validation/UuidValue.java
@@ -1,3 +1,18 @@
+/**
+ *  Copyright 2017 incub8 Software Labs GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.github.mizool.validation;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;


### PR DESCRIPTION
* Added NOTICE file, including the content from <https://github.com/tomitribe/jcache-cdi>.
* Verified <https://github.com/jsr107/RI> did not have NOTICE requirements.
* As required by the license, added prominent notices to files that were changed for Mizool.