### PR TITLE
Travis now skips release/hotfix branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,8 @@ env:
     - # ^^ GPG_KEY_NAME
     - secure: "u2hl0ZLglR6Ao1KyXStIm5ZKjiJT2GCBXiawqB8XKKDUWqNjKmf2CkblXN23AkLDThTIMkoXom83y3WPbIsaL24KSHeivfa2x5bU6stTksbAusJ+3WCXO7ceDZqiqqnBWRUBYDGQQpuAd2vx3F8VgCpUnCWZP9acqRnPBhSn/+P4GTLLFY6LaFL32vv4Nh5vC+s3tTv6tMg89UTH9I5GVeLuGwGe3B4Jg6CRcqzIwo6GTmPrQ3un8lEFCkO5eAYceUcM0UePfBTHvVcpAuCPIbduWJWEEjSy577EN6DDVb8brPTEojQBUVhKjjz2YLkTX7f3oyqfTsdRGghxWjehlvj/M4/BXxabeFM/4R2vanaxEjQiLkLfqbu9oYNEWPG5qG39hvaw2Ay9BLGOkHqkasl3nhywJw4TWiqemd3jKhjEIQuL5Hpmls4Db5KMNmQ8/io3xAJcCt3vOjoNrkpeeplk/EMlT8Ha0puxrOKH/jZsrXyQ9Ox8tFjUs2ZWI4+H7Hj8DxFkG+YwHKtGDtj/bpJyYrJnZbmH3I9x2dUL/2VcmuqjajWG/JoQdPOiParAPJj0KbKv1jNfBbF8pNu0uqBs2pgiM4BTplDe27/i9iimbI0fixo5kx/eQNKeX4EvpefX7NmP/L+06SvSza4k3vvArvaE8px8NgatFfllozU="
     - # ^^ GPG_PASSPHRASE
+
+branches:
+  except:
+    - /^release-.*$/
+    - /^hotfix-.*$/


### PR DESCRIPTION
- As jgitflow deletes the release branch during the release-finish goal, the Travis build for that branch always failed.