### PR TITLE
AuthenticationRejectedException now inherits from Shiro Authenticatio…

### DIFF
--- a/src/main/java/com/github/mizool/rest/errorhandling/DefaultWhiteList.java
+++ b/src/main/java/com/github/mizool/rest/errorhandling/DefaultWhiteList.java
@@ -24,13 +24,13 @@ import org.kohsuke.MetaInfServices;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.github.mizool.exception.AuthenticationMissingException;
-import com.github.mizool.exception.AuthenticationRejectedException;
 import com.github.mizool.exception.BadRequestException;
 import com.github.mizool.exception.ConflictingEntityException;
 import com.github.mizool.exception.ObjectNotFoundException;
 import com.github.mizool.exception.PermissionDeniedException;
 import com.github.mizool.exception.UnprocessableEntityException;
 import com.github.mizool.exception.UnsupportedHttpFeatureException;
+import com.github.mizool.shiro.AuthenticationRejectedException;
 import com.google.common.collect.ImmutableMap;
 
 @MetaInfServices

--- a/src/main/java/com/github/mizool/shiro/AuthenticationRejectedException.java
+++ b/src/main/java/com/github/mizool/shiro/AuthenticationRejectedException.java
@@ -14,9 +14,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.github.mizool.exception;
+package com.github.mizool.shiro;
 
-public class AuthenticationRejectedException extends RuntimeException
+import org.apache.shiro.authc.AuthenticationException;
+
+public class AuthenticationRejectedException extends AuthenticationException
 {
     public AuthenticationRejectedException()
     {
@@ -35,11 +37,5 @@ public class AuthenticationRejectedException extends RuntimeException
     public AuthenticationRejectedException(Throwable cause)
     {
         super(cause);
-    }
-
-    public AuthenticationRejectedException(
-        String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace)
-    {
-        super(message, cause, enableSuppression, writableStackTrace);
     }
 }


### PR DESCRIPTION
Shiro was throwing a warning that exceptions during the login process should inherit from the AuthenticationException