### PR TITLE
disabled output of dates as timestamps

### DIFF
--- a/technology/jackson/src/main/java/com/github/mizool/technology/jackson/CustomObjectMapperProducer.java
+++ b/technology/jackson/src/main/java/com/github/mizool/technology/jackson/CustomObjectMapperProducer.java
@@ -32,6 +32,7 @@ public class CustomObjectMapperProducer
     {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.registerModule(new GuavaModule());


### PR DESCRIPTION
disabling this feature forces jackson to use the standard ISO Formatter to output dates etc. as String