### PR TITLE
Feature/sonar 20180518

### DIFF
--- a/core/src/main/java/com/github/mizool/core/validation/ConstraintValidatorAdapter.java
+++ b/core/src/main/java/com/github/mizool/core/validation/ConstraintValidatorAdapter.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 incub8 Software Labs GmbH
+ * Copyright 2018 protel Hotelsoftware GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mizool.core.validation;
+
+import java.lang.annotation.Annotation;
+
+import javax.validation.ConstraintValidator;
+
+public abstract class ConstraintValidatorAdapter<A extends Annotation, T> implements ConstraintValidator<A, T>
+{
+    @Override
+    public void initialize(A constraintAnnotation)
+    {
+        // Override when needed
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,22 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.github.mizool.jcache</groupId>
+                <artifactId>cache-annotations-ri-cdi</artifactId>
+                <version>${jcache.ri.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.enterprise</groupId>
+                        <artifactId>cdi-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.github.mizool.jcache</groupId>
+                <artifactId>cache-annotations-ri-common</artifactId>
+                <version>${jcache.ri.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.mizool.technology</groupId>
                 <artifactId>technology-aws</artifactId>
                 <version>${project.version}</version>
@@ -188,22 +204,6 @@
                 <groupId>com.github.mizool.technology</groupId>
                 <artifactId>technology-web</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.mizool.jcache</groupId>
-                <artifactId>cache-annotations-ri-cdi</artifactId>
-                <version>${jcache.ri.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.enterprise</groupId>
-                        <artifactId>cdi-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.github.mizool.jcache</groupId>
-                <artifactId>cache-annotations-ri-common</artifactId>
-                <version>${jcache.ri.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/technology/web/src/main/java/com/github/mizool/technology/web/AbstractErrorHandlingFilter.java
+++ b/technology/web/src/main/java/com/github/mizool/technology/web/AbstractErrorHandlingFilter.java
@@ -1,27 +1,25 @@
 /**
- *  Copyright 2017 incub8 Software Labs GmbH
- *  Copyright 2017 protel Hotelsoftware GmbH
+ * Copyright 2017-2018 incub8 Software Labs GmbH
+ * Copyright 2017-2018 protel Hotelsoftware GmbH
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.github.mizool.technology.web;
 
 import java.io.IOException;
 
 import javax.inject.Inject;
-import javax.servlet.Filter;
 import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -31,7 +29,7 @@ import com.github.mizool.core.rest.errorhandling.ErrorHandler;
 import com.github.mizool.core.rest.errorhandling.ErrorMessageDto;
 import com.github.mizool.core.rest.errorhandling.ErrorResponse;
 
-public abstract class AbstractErrorHandlingFilter implements Filter
+public abstract class AbstractErrorHandlingFilter extends FilterAdapter
 {
     @Inject
     private ErrorHandler errorHandler;
@@ -63,14 +61,4 @@ public abstract class AbstractErrorHandlingFilter implements Filter
     }
 
     protected abstract byte[] getErrorMessageJsonBytes(ErrorMessageDto errorMessageDto);
-
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException
-    {
-    }
-
-    @Override
-    public void destroy()
-    {
-    }
 }

--- a/technology/web/src/main/java/com/github/mizool/technology/web/CacheHeaderFilter.java
+++ b/technology/web/src/main/java/com/github/mizool/technology/web/CacheHeaderFilter.java
@@ -1,18 +1,18 @@
 /**
- *  Copyright 2017 incub8 Software Labs GmbH
- *  Copyright 2017 protel Hotelsoftware GmbH
+ * Copyright 2017-2018 incub8 Software Labs GmbH
+ * Copyright 2017-2018 protel Hotelsoftware GmbH
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.github.mizool.technology.web;
 
@@ -21,24 +21,17 @@ import java.util.Calendar;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.Filter;
 import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-public class CacheHeaderFilter implements Filter
+public class CacheHeaderFilter extends FilterAdapter
 {
     private static final Pattern STATIC_ELEMENTS_PATH_PATTERN = Pattern.compile(
         "^/(webjars|\\d+(\\.\\d+)*(-[\\dA-Za-z]+)?)/.+$");
-
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException
-    {
-    }
 
     @Override
     public void doFilter(
@@ -85,10 +78,5 @@ public class CacheHeaderFilter implements Filter
         response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
         response.setHeader("Pragma", "no-cache");
         response.setDateHeader("Expires", 0);
-    }
-
-    @Override
-    public void destroy()
-    {
     }
 }

--- a/technology/web/src/main/java/com/github/mizool/technology/web/FilterAdapter.java
+++ b/technology/web/src/main/java/com/github/mizool/technology/web/FilterAdapter.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2018 incub8 Software Labs GmbH
+ * Copyright 2018 protel Hotelsoftware GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mizool.technology.web;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+
+public abstract class FilterAdapter implements Filter
+{
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException
+    {
+        // Override when needed
+    }
+
+    @Override
+    public void destroy()
+    {
+        // Override when needed
+    }
+}


### PR DESCRIPTION
- fixed S1186: Methods should not be empty. Introduced FilterAdapter because most Filters have empty init() and destroy() methods.
- fixed S1186: Methods should not be empty. Introduced ConstraintValidatorAdapter because some validators have empty initialize() methods.