### PR TITLE
Revert "Updated the guava version and deprecated the GuavaCollectors."

### DIFF
--- a/core/src/main/java/com/github/mizool/core/GuavaCollectors.java
+++ b/core/src/main/java/com/github/mizool/core/GuavaCollectors.java
@@ -95,57 +95,49 @@ public final class GuavaCollectors
         }
     }
 
-    /**
-     * @deprecated Use {@link ImmutableList#toImmutableList()} instead.
-     */
-    @Deprecated
-    public static <T> Collector<T, ?, ImmutableList<T>> toImmutableList()
+    public static <T> Collector<T, ImmutableList.Builder<T>, ImmutableList<T>> toImmutableList()
     {
-        return ImmutableList.toImmutableList();
+        return new CollectorImpl<>(
+            ImmutableList::builder,
+            ImmutableList.Builder::add,
+            (thisBuilder, otherBuilder) -> thisBuilder.addAll(otherBuilder.build()),
+            ImmutableList.Builder::build);
     }
 
-    /**
-     * @deprecated Use {@link ImmutableSet#toImmutableSet()} instead.
-     */
-    @Deprecated
-    public static <T> Collector<T, ?, ImmutableSet<T>> toImmutableSet()
+    public static <T> Collector<T, ImmutableSet.Builder<T>, ImmutableSet<T>> toImmutableSet()
     {
-        return ImmutableSet.toImmutableSet();
+        return new CollectorImpl<>(
+            ImmutableSet::builder,
+            ImmutableSet.Builder::add,
+            (thisBuilder, otherBuilder) -> thisBuilder.addAll(otherBuilder.build()),
+            ImmutableSet.Builder::build);
     }
 
-    /**
-     * @deprecated Use {@link ImmutableMap#toImmutableMap(Function, Function)} instead.
-     */
-    @Deprecated
-    public static <T, K, U> Collector<T, ?, ImmutableMap<K, U>> toImmutableMap(
-        Function<? super T, ? extends K> keyFunction, Function<? super T, ? extends U> valueFunction)
+    public static <T, K, U> Collector<T, ImmutableMap.Builder<K, U>, ImmutableMap<K, U>> toImmutableMap(
+        Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends U> valueMapper)
     {
-        return ImmutableMap.toImmutableMap(keyFunction, valueFunction);
+        return new CollectorImpl<>(
+            ImmutableMap::builder,
+            (builder, element) -> builder.put(keyMapper.apply(element), valueMapper.apply(element)),
+            (thisBuilder, otherBuilder) -> thisBuilder.putAll(otherBuilder.build()),
+            ImmutableMap.Builder::build);
     }
 
-    /**
-     * @deprecated Use {@link ImmutableListMultimap#toImmutableListMultimap(Function, Function)} instead. Note the
-     * slightly different signature of the {@code valueFunction}.
-     */
-    @Deprecated
     public static <T, K, U> Collector<T, ImmutableListMultimap.Builder<K, U>, ImmutableListMultimap<K, U>> toImmutableListMultimap(
         Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends List<U>> valueMapper)
     {
-        return new CollectorImpl<>(ImmutableListMultimap::builder,
+        return new CollectorImpl<>(
+            ImmutableListMultimap::builder,
             (builder, element) -> builder.putAll(keyMapper.apply(element), valueMapper.apply(element)),
             (thisBuilder, otherBuilder) -> thisBuilder.putAll(otherBuilder.build()),
             ImmutableListMultimap.Builder::build);
     }
 
-    /**
-     * @deprecated Use {@link ImmutableSetMultimap#toImmutableSetMultimap(Function, Function)} instead. Note the
-     * slightly different signature of the {@code valueFunction}.
-     */
-    @Deprecated
     public static <T, K, U> Collector<T, ImmutableSetMultimap.Builder<K, U>, ImmutableSetMultimap<K, U>> toImmutableSetMultimap(
         Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends Set<U>> valueMapper)
     {
-        return new CollectorImpl<>(ImmutableSetMultimap::builder,
+        return new CollectorImpl<>(
+            ImmutableSetMultimap::builder,
             (builder, element) -> builder.putAll(keyMapper.apply(element), valueMapper.apply(element)),
             (thisBuilder, otherBuilder) -> thisBuilder.putAll(otherBuilder.build()),
             ImmutableSetMultimap.Builder::build);

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>25.0-jre</version>
+                <version>20.0</version>
             </dependency>
             <dependency>
                 <!-- force dependency convergence. 1.1.3 is intended for aws-java-sdk-dynamodb 1.11.75 -->


### PR DESCRIPTION
This reverts commit 8f506e21f25acbe96d4d84c36a6d191a9d3593d5.

The new guava version breaks a downstream project that uses the `maven-plugin-plugin` in version 3.3. Updating to a newer version of the `maven-plugin-plugin` is not possible at the moment as the underlying parser of the new version has a bug that prevents it from running on said downstream project.