### PR TITLE
Added Optionals.mapToValue() to simplify stream pipelines.

### DIFF
--- a/core/src/main/java/com/github/mizool/core/Optionals.java
+++ b/core/src/main/java/com/github/mizool/core/Optionals.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017-2019 incub8 Software Labs GmbH
  * Copyright 2017-2019 protel Hotelsoftware GmbH
  *
@@ -119,7 +119,7 @@ public class Optionals
      *     .map(Optional::get)
      * }</pre>
      */
-    public <T> Stream<T> streamPresentValue(Optional<T> optional)
+    public <T> Stream<T> streamPresentValue(@NonNull Optional<T> optional)
     {
         return optional.map(Stream::of).orElseGet(Stream::empty);
     }

--- a/core/src/main/java/com/github/mizool/core/Optionals.java
+++ b/core/src/main/java/com/github/mizool/core/Optionals.java
@@ -106,11 +106,12 @@ public class Optionals
     }
 
     /**
-     * Used in streams to {@linkplain Stream#flatMap(Function) flat-map} each {@link Optional} to its value if present.<br>
+     * Used in streams to {@linkplain Stream#flatMap(Function) flat-map} each {@link Optional} to its value if
+     * present.<br>
      * <br>
      * This method is intended to be used as follows:
      * <pre>{@code
-     *     .flatMap(Optionals::mapToValue)
+     *     .flatMap(Optionals::streamPresentValue)
      * }</pre>
      * Using this method is equivalent of chaining {@link Optional#isPresent()} and {@link Optional#get()} like this:
      * <pre>{@code
@@ -118,7 +119,7 @@ public class Optionals
      *     .map(Optional::get)
      * }</pre>
      */
-    public <T> Stream<T> mapToValue(Optional<T> optional)
+    public <T> Stream<T> streamPresentValue(Optional<T> optional)
     {
         return optional.map(Stream::of).orElseGet(Stream::empty);
     }

--- a/core/src/main/java/com/github/mizool/core/Optionals.java
+++ b/core/src/main/java/com/github/mizool/core/Optionals.java
@@ -17,6 +17,8 @@
 package com.github.mizool.core;
 
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
@@ -101,5 +103,23 @@ public class Optionals
             throw new UnprocessableEntityException(classOfT.getSimpleName() + " not found");
         }
         return wrapped.get();
+    }
+
+    /**
+     * Used in streams to {@linkplain Stream#flatMap(Function) flat-map} each {@link Optional} to its value if present.<br>
+     * <br>
+     * This method is intended to be used as follows:
+     * <pre>{@code
+     *     .flatMap(Optionals::mapToValue)
+     * }</pre>
+     * Using this method is equivalent of chaining {@link Optional#isPresent()} and {@link Optional#get()} like this:
+     * <pre>{@code
+     *     .filter(Optional::isPresent)
+     *     .map(Optional::get)
+     * }</pre>
+     */
+    public <T> Stream<T> mapToValue(Optional<T> optional)
+    {
+        return optional.map(Stream::of).orElseGet(Stream::empty);
     }
 }

--- a/core/src/test/java/com/github/mizool/core/TestOptionals.java
+++ b/core/src/test/java/com/github/mizool/core/TestOptionals.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,28 +31,29 @@ import com.google.common.collect.ImmutableList;
 public class TestOptionals
 {
     @Test(dataProvider = "optionalStreams")
-    public <T> void testMapToValue(Collection<Optional<T>> input, Iterable<T> expected)
+    public <T> void testStreamPresentValue(String testName, Collection<Optional<T>> input, Iterable<T> expected)
     {
-        List<T> actual = input.stream().flatMap(Optionals::mapToValue).collect(Collectors.toList());
-        assertThat(actual).containsExactlyElementsOf(expected);
+        List<T> actual = input.stream().flatMap(Optionals::streamPresentValue).collect(ImmutableList.toImmutableList());
+        assertThat(actual).containsOnlyElementsOf(expected);
     }
 
     @DataProvider
     private Object[][] optionalStreams()
     {
-        List<Object> emptyList = Collections.emptyList();
+        List<Void> emptyList = Collections.emptyList();
 
-        Optional<Object> empty = Optional.empty();
+        Optional<Void> empty = Optional.empty();
         Optional<String> a = Optional.of("a");
         Optional<String> b = Optional.of("b");
         Optional<String> c = Optional.of("c");
 
         return new Object[][]{
-            { emptyList, emptyList },
-            { ImmutableList.of(empty), emptyList },
-            { ImmutableList.of(a), ImmutableList.of("a") },
-            { ImmutableList.of(a, b, c), ImmutableList.of("a", "b", "c") },
-            { ImmutableList.of(a, empty, c), ImmutableList.of("a", "c") }
+            { "empty stream", emptyList, emptyList },
+            { "isolated empty optional", ImmutableList.of(empty), emptyList },
+            { "single value", ImmutableList.of(a), ImmutableList.of("a") },
+            { "multiple values", ImmutableList.of(a, b, c), ImmutableList.of("a", "b", "c") },
+            { "empty optional among values", ImmutableList.of(a, empty, c), ImmutableList.of("a", "c") },
+            { "multiple equal values", ImmutableList.of(a, a), ImmutableList.of("a", "a") }
         };
     }
 }

--- a/core/src/test/java/com/github/mizool/core/TestOptionals.java
+++ b/core/src/test/java/com/github/mizool/core/TestOptionals.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 incub8 Software Labs GmbH
  * Copyright 2019 protel Hotelsoftware GmbH
  *
@@ -20,27 +20,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class TestOptionals
 {
     @Test(dataProvider = "optionalStreams")
     public <T> void testStreamPresentValue(String testName, Collection<Optional<T>> input, Iterable<T> expected)
     {
-        List<T> actual = input.stream().flatMap(Optionals::streamPresentValue).collect(ImmutableList.toImmutableList());
+        Iterable<T> actual = input.stream()
+            .flatMap(Optionals::streamPresentValue)
+            .collect(ImmutableSet.toImmutableSet());
         assertThat(actual).containsOnlyElementsOf(expected);
     }
 
     @DataProvider
     private Object[][] optionalStreams()
     {
-        List<Void> emptyList = Collections.emptyList();
+        Set<Void> emptyList = Collections.emptySet();
 
         Optional<Void> empty = Optional.empty();
         Optional<String> a = Optional.of("a");
@@ -49,11 +51,11 @@ public class TestOptionals
 
         return new Object[][]{
             { "empty stream", emptyList, emptyList },
-            { "isolated empty optional", ImmutableList.of(empty), emptyList },
-            { "single value", ImmutableList.of(a), ImmutableList.of("a") },
-            { "multiple values", ImmutableList.of(a, b, c), ImmutableList.of("a", "b", "c") },
-            { "empty optional among values", ImmutableList.of(a, empty, c), ImmutableList.of("a", "c") },
-            { "multiple equal values", ImmutableList.of(a, a), ImmutableList.of("a", "a") }
+            { "isolated empty optional", ImmutableSet.of(empty), emptyList },
+            { "single value", ImmutableSet.of(a), ImmutableSet.of("a") },
+            { "multiple values", ImmutableSet.of(a, b, c), ImmutableSet.of("a", "b", "c") },
+            { "empty optional among values", ImmutableSet.of(a, empty, c), ImmutableSet.of("a", "c") },
+            { "multiple equal values", ImmutableSet.of(a, a), ImmutableSet.of("a", "a") }
         };
     }
 }

--- a/core/src/test/java/com/github/mizool/core/TestOptionals.java
+++ b/core/src/test/java/com/github/mizool/core/TestOptionals.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2019 incub8 Software Labs GmbH
+ * Copyright 2019 protel Hotelsoftware GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.mizool.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class TestOptionals
+{
+    @Test(dataProvider = "optionalStreams")
+    public <T> void testMapToValue(Collection<Optional<T>> input, Iterable<T> expected)
+    {
+        List<T> actual = input.stream().flatMap(Optionals::mapToValue).collect(Collectors.toList());
+        assertThat(actual).containsExactlyElementsOf(expected);
+    }
+
+    @DataProvider
+    private Object[][] optionalStreams()
+    {
+        List<Object> emptyList = Collections.emptyList();
+
+        Optional<Object> empty = Optional.empty();
+        Optional<String> a = Optional.of("a");
+        Optional<String> b = Optional.of("b");
+        Optional<String> c = Optional.of("c");
+
+        return new Object[][]{
+            { emptyList, emptyList },
+            { ImmutableList.of(empty), emptyList },
+            { ImmutableList.of(a), ImmutableList.of("a") },
+            { ImmutableList.of(a, b, c), ImmutableList.of("a", "b", "c") },
+            { ImmutableList.of(a, empty, c), ImmutableList.of("a", "c") }
+        };
+    }
+}


### PR DESCRIPTION
I had this in a private codebase in a `MoreOptionals` helper class, but IMO it really belongs here as other codebases can benefit from it. 

Method name is up for debate.