### PR TITLE
Added store converter to serialize complex pojo fields into JSON. GENIUS-1531

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,6 +18,11 @@
             <artifactId>jcommander</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/core/src/main/java/com/github/mizool/core/converter/JsonConverter.java
+++ b/core/src/main/java/com/github/mizool/core/converter/JsonConverter.java
@@ -1,0 +1,53 @@
+package com.github.mizool.core.converter;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mizool.core.exception.StoreLayerException;
+
+@RequiredArgsConstructor(onConstructor = @__(@Inject), access = AccessLevel.PROTECTED)
+public class JsonConverter
+{
+    private final ObjectMapper objectMapper;
+
+    public <P> String toRecord(P pojo)
+    {
+        String record = null;
+        if (pojo != null)
+        {
+            try
+            {
+                record = objectMapper.writeValueAsString(pojo);
+            }
+            catch (JsonProcessingException e)
+            {
+                throw new StoreLayerException("Error serializing field", e);
+            }
+        }
+        return record;
+    }
+
+    public <P> P toPojo(String record, TypeReference<P> type)
+    {
+        P pojo = null;
+        if (record != null)
+        {
+            try
+            {
+                pojo = objectMapper.readValue(record, type);
+            }
+            catch (IOException e)
+            {
+                throw new StoreLayerException("Error deserializing field", e);
+            }
+        }
+        return pojo;
+    }
+}


### PR DESCRIPTION
In genius, we will use this to store sets and maps without having to normalize our tables (which would complicate things in the store layer). The idea to use JSON serialization for that is borrowed from the Cassandra world, where we had problems using Cassandras collection support and decided to perform the serialization ourselves. Sadly, since this decision was made, there was no time to implement it anywhere.

Note that since this converter can't possibly traverse the object tree to check for `null` collections, the converter that calls this one will have to wrap the call if needed.