### PR TITLE
added mapper option to write unset instead of null into columns, prev…

### DIFF
--- a/technology/cassandra/src/main/resources/com/github/mizool/technology/cassandra/mapperProducerGenerator.stg
+++ b/technology/cassandra/src/main/resources/com/github/mizool/technology/cassandra/mapperProducerGenerator.stg
@@ -45,6 +45,7 @@ class $className$MapperProducer
         mapper.setDefaultGetOptions(Option.consistencyLevel(DefaultConsistencyLevel.READ));
         mapper.setDefaultSaveOptions(Option.consistencyLevel(DefaultConsistencyLevel.WRITE));
         mapper.setDefaultDeleteOptions(Option.consistencyLevel(DefaultConsistencyLevel.WRITE));
+        mapper.setDefaultSaveOptions(Mapper.Option.saveNullFields(false));
         return mapper;
     }
 }


### PR DESCRIPTION
we recently discovered that cassandra creates a tombstone for each cell when value of the cell is null.
See this article for details: https://opencredo.com/blogs/cassandra-tombstones-common-issues/
To prevent this behvior, the mapper has an option to store a cell with value unset instead of null.