### PR TITLE
include details in LockedEntityException

### DIFF
--- a/core/src/main/java/com/github/mizool/core/rest/errorhandling/behavior/LockedEntityExceptionBehavior.java
+++ b/core/src/main/java/com/github/mizool/core/rest/errorhandling/behavior/LockedEntityExceptionBehavior.java
@@ -25,7 +25,7 @@ public class LockedEntityExceptionBehavior implements ErrorHandlingBehavior
     @Override
     public boolean includeDetails()
     {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
we would like to include details in locked entity exceptions for frontends to distinguish between different kind of locks