### PR TITLE
carriage return (\r) is now stripped from key files

### DIFF
--- a/core/src/main/java/com/github/mizool/core/rsa/RsaKeys.java
+++ b/core/src/main/java/com/github/mizool/core/rsa/RsaKeys.java
@@ -21,7 +21,7 @@ import com.github.mizool.core.exception.ConfigurationException;
 public class RsaKeys
 {
     private final Pattern HEADER_FOOTER_AND_LINE_BREAKS = Pattern.compile(
-        "(?:-----(?:BEGIN|END).+?(?:PRIVATE|PUBLIC) KEY-----|\\n)");
+        "(?:-----(?:BEGIN|END).+?(?:PRIVATE|PUBLIC) KEY-----|\\n|\\r)");
 
     public RSAPrivateKey privateKeyFromPkcs8(String src)
     {

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
             <organizationUrl>http://www.incub8.de</organizationUrl>
         </developer>
         <developer>
+            <name>Rick Striewe</name>
+            <email>rickstriewe@incub8.de</email>
+            <organization>incub8 Software Labs</organization>
+            <organizationUrl>http://www.incub8.de</organizationUrl>
+        </developer>
+        <developer>
             <name>Sven Haberer</name>
             <email>svenhaberer@incub8.de</email>
             <organization>incub8 Software Labs</organization>


### PR DESCRIPTION
in fact this did not even compile on my local system (Windows 10) before changing the regex.