### PR TITLE
Update metainf-services to support JDK >8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
             <dependency>
                 <groupId>org.kohsuke.metainf-services</groupId>
                 <artifactId>metainf-services</artifactId>
-                <version>1.6</version>
+                <version>1.8</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
`@MetaInfServices` annotation processor was skipped when using newer JDKs. As of `metainf-services` 1.8, the processor [will work with any future JDK](https://github.com/kohsuke/metainf-services/pull/15).