### PR TITLE
Add "unprocessable entity" exception types for common cases

### DIFF
--- a/core/src/main/java/com/github/mizool/core/exception/GeneratedFieldOverrideException.java
+++ b/core/src/main/java/com/github/mizool/core/exception/GeneratedFieldOverrideException.java
@@ -1,0 +1,28 @@
+package com.github.mizool.core.exception;
+
+/**
+ * Thrown when an attempt is made to set a value for a field which is automatically generated or maintained, such as the
+ * identifier or timestamps.
+ */
+public class GeneratedFieldOverrideException extends AbstractUnprocessableEntityException
+{
+    public GeneratedFieldOverrideException()
+    {
+        super();
+    }
+
+    public GeneratedFieldOverrideException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public GeneratedFieldOverrideException(String message)
+    {
+        super(message);
+    }
+
+    public GeneratedFieldOverrideException(Throwable cause)
+    {
+        super(cause);
+    }
+}

--- a/core/src/main/java/com/github/mizool/core/exception/GeneratedFieldOverrideException.java
+++ b/core/src/main/java/com/github/mizool/core/exception/GeneratedFieldOverrideException.java
@@ -1,28 +1,20 @@
 package com.github.mizool.core.exception;
 
+import lombok.Getter;
+import lombok.NonNull;
+
 /**
  * Thrown when an attempt is made to set a value for a field which is automatically generated or maintained, such as the
  * identifier or timestamps.
  */
 public class GeneratedFieldOverrideException extends AbstractUnprocessableEntityException
 {
-    public GeneratedFieldOverrideException()
-    {
-        super();
-    }
+    @Getter
+    private final String fieldName;
 
-    public GeneratedFieldOverrideException(String message, Throwable cause)
+    public GeneratedFieldOverrideException(@NonNull String fieldName)
     {
-        super(message, cause);
-    }
-
-    public GeneratedFieldOverrideException(String message)
-    {
-        super(message);
-    }
-
-    public GeneratedFieldOverrideException(Throwable cause)
-    {
-        super(cause);
+        super(String.format("Generated field %s must not be specified", fieldName));
+        this.fieldName = fieldName;
     }
 }

--- a/core/src/main/java/com/github/mizool/core/exception/InvalidPrimaryKeyException.java
+++ b/core/src/main/java/com/github/mizool/core/exception/InvalidPrimaryKeyException.java
@@ -2,7 +2,9 @@ package com.github.mizool.core.exception;
 
 /**
  * Thrown when the primary key of the entity is invalid. This is used both for general rules (e.g. primary key cannot be
- * {@code null}) and situational checks (e.g. primary key cannot be changed as part of an update).
+ * {@code null}) and situational checks (e.g. primary key cannot be changed as part of an update).<br>
+ * <br>
+ * If the primary key is already in use by another record, use {@link ConflictingEntityException} instead.
  */
 public class InvalidPrimaryKeyException extends AbstractUnprocessableEntityException
 {

--- a/core/src/main/java/com/github/mizool/core/exception/InvalidPrimaryKeyException.java
+++ b/core/src/main/java/com/github/mizool/core/exception/InvalidPrimaryKeyException.java
@@ -1,0 +1,28 @@
+package com.github.mizool.core.exception;
+
+/**
+ * Thrown when the primary key of the entity is invalid. This is used both for general rules (e.g. primary key cannot be
+ * {@code null}) and situational checks (e.g. primary key cannot be changed as part of an update).
+ */
+public class InvalidPrimaryKeyException extends AbstractUnprocessableEntityException
+{
+    public InvalidPrimaryKeyException()
+    {
+        super();
+    }
+
+    public InvalidPrimaryKeyException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public InvalidPrimaryKeyException(String message)
+    {
+        super(message);
+    }
+
+    public InvalidPrimaryKeyException(Throwable cause)
+    {
+        super(cause);
+    }
+}

--- a/core/src/main/java/com/github/mizool/core/exception/ReadonlyFieldException.java
+++ b/core/src/main/java/com/github/mizool/core/exception/ReadonlyFieldException.java
@@ -1,28 +1,29 @@
 package com.github.mizool.core.exception;
 
+import lombok.Getter;
+import lombok.NonNull;
+
 /**
  * Thrown when an attempt is made to change the value of a field that is considered read-only for the current operation.
  * For example, it may be forbidden to change the name of a user group, although it must be set when creating one.
  */
+@Getter
 public class ReadonlyFieldException extends AbstractUnprocessableEntityException
 {
-    public ReadonlyFieldException()
+    private final String fieldName;
+    private final String recordId;
+
+    public ReadonlyFieldException(@NonNull String fieldName)
     {
-        super();
+        super(String.format("Attempt to update readonly field %s", fieldName));
+        this.fieldName = fieldName;
+        recordId = null;
     }
 
-    public ReadonlyFieldException(String message, Throwable cause)
+    public ReadonlyFieldException(@NonNull String fieldName, @NonNull String recordId)
     {
-        super(message, cause);
-    }
-
-    public ReadonlyFieldException(String message)
-    {
-        super(message);
-    }
-
-    public ReadonlyFieldException(Throwable cause)
-    {
-        super(cause);
+        super(String.format("Attempt to update readonly field %s of '%s'", fieldName, recordId));
+        this.fieldName = fieldName;
+        this.recordId = recordId;
     }
 }

--- a/core/src/main/java/com/github/mizool/core/exception/ReadonlyFieldException.java
+++ b/core/src/main/java/com/github/mizool/core/exception/ReadonlyFieldException.java
@@ -1,0 +1,28 @@
+package com.github.mizool.core.exception;
+
+/**
+ * Thrown when an attempt is made to change the value of a field that is considered read-only for the current operation.
+ * For example, it may be forbidden to change the name of a user group, although it must be set when creating one.
+ */
+public class ReadonlyFieldException extends AbstractUnprocessableEntityException
+{
+    public ReadonlyFieldException()
+    {
+        super();
+    }
+
+    public ReadonlyFieldException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public ReadonlyFieldException(String message)
+    {
+        super(message);
+    }
+
+    public ReadonlyFieldException(Throwable cause)
+    {
+        super(cause);
+    }
+}


### PR DESCRIPTION
Following up on #195, here are three exception types that can be used by store classes.

The goal is to avoid that each application defines similar exceptions (or worse, one set for each entity) for these common cases. 

IMO, their definition is sufficiently narrow to avoid them becoming the next "used for everything" exception that threatens the ability of applications to be properly internationalized.


## Notes

- I considered adding specialized constructors that take the field name, but ultimately decided against it: all three exception types cover cases that represent programming errors in a UI (or wrong usage when manually invoking REST APIs), so having placeholders and enabling error messages that say e.g. "Dear user, the field XXX should not be set for new entities" does not make much sense.
- The necessity to have these was discovered while working on the proof of concept code for our improved records helper.
