### PR TITLE
More Synchronizer options

### DIFF
--- a/core/src/main/java/com/github/mizool/core/concurrent/Synchronizer.java
+++ b/core/src/main/java/com/github/mizool/core/concurrent/Synchronizer.java
@@ -137,11 +137,19 @@ public final class Synchronizer implements SynchronizerApi.SleepRunGet
         private SleepSpec(@NonNull BooleanSupplier condition, @Nullable Duration interval)
         {
             this.condition = condition;
+            waitTimeoutMillis = toWaitTimeoutMillis(interval);
+        }
 
-            // If the user doesn't specify an interval, we default to zero, which wait() interprets as "indefinite".
-            this.waitTimeoutMillis = interval == null
-                ? 0
-                : interval.toMillis();
+        /**
+         * If the user doesn't specify an interval, we default to zero, which wait() interprets as "indefinite".
+         */
+        private long toWaitTimeoutMillis(Duration interval)
+        {
+            if (interval == null)
+            {
+                return 0;
+            }
+            return interval.toMillis();
         }
     }
 

--- a/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
+++ b/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
@@ -6,32 +6,26 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
- * Provides fluent syntax for for {@link Synchronizer}.
+ * Provides fluent syntax for {@link Synchronizer}.
  */
 public interface SynchronizerApi
 {
-    /*
-     * Note on terminology: this API intentionally uses the verbs "sleep" and "wake". If it used "wait" and "notify"
-     * instead, its methods would all too easily be confused with methods in java.lang.Object which, if invoked on the
-     * objects returned by chained methods, could cause deadlocks.
-     */
-
     interface SleepRunGet extends RunGet
     {
         /**
          * Adds sleeping to the action chain. <br>
          * <br>
-         * When performing this action, the chain will ensure the given condition is met before performing the main
+         * When performing this action, the chain will ensure the given condition is met before performing the next
          * action. If the supplier returns {@code false}, this action chain sleeps until another chain wakes it up.
          * Then, the supplier is called again and if it still returns {@code false}, the chain resumes sleeping.
-         * Otherwise, the chain continues by performing the main action.
+         * Otherwise, the chain proceeds to perform the next action.
          *
          * @param state the supplier that returns {@code true} if the action chain should continue, {@code false}
          * otherwise.
          *
          * @throws NullPointerException if {@code state} is null
          */
-        default RunGet sleepUntil(BooleanSupplier state)
+        default RunGetInvoke sleepUntil(BooleanSupplier state)
         {
             return sleepUntil(state, null);
         }
@@ -39,10 +33,10 @@ public interface SynchronizerApi
         /**
          * Adds sleeping to the action chain. <br>
          * <br>
-         * When performing this action, the chain will ensure the given condition is met before performing the main
+         * When performing this action, the chain will ensure the given condition is met before performing the next
          * action. If the supplier returns {@code false}, this action chain sleeps until either another chain wakes it
          * up or the timeout has passed. Then, the supplier is called again and if it still returns {@code false}, the
-         * chain resumes sleeping. Otherwise, the chain continues by performing the main action.
+         * chain resumes sleeping. Otherwise, the chain proceeds to perform the next action.
          *
          * @param state the supplier that returns {@code true} if the action chain should continue, {@code false}
          * otherwise.
@@ -51,7 +45,7 @@ public interface SynchronizerApi
          *
          * @throws NullPointerException if {@code state} is null
          */
-        RunGet sleepUntil(BooleanSupplier state, Duration timeout);
+        RunGetInvoke sleepUntil(BooleanSupplier state, Duration timeout);
 
         /**
          * Adds an action which wakes other chains.
@@ -63,7 +57,7 @@ public interface SynchronizerApi
         }
     }
 
-    interface RunGet extends Run.Invoke
+    interface RunGet
     {
         /**
          * Sets the given {@link Runnable} as the main action of the chain.
@@ -82,7 +76,10 @@ public interface SynchronizerApi
          * @throws NullPointerException if {@code getter} is null
          */
         <T> Get.WakeSleepInvoke<T> get(Supplier<T> getter);
+    }
 
+    interface RunGetInvoke extends RunGet, Run.Invoke
+    {
         @Override
         default void invoke()
         {

--- a/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
+++ b/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
@@ -52,6 +52,15 @@ public interface SynchronizerApi
          * @throws NullPointerException if {@code state} is null
          */
         RunGet sleepUntil(BooleanSupplier state, Duration timeout);
+
+        /**
+         * Adds an action which wakes other chains.
+         */
+        default Run.Invoke wakeOthers()
+        {
+            return run(() -> {
+            }).andWakeOthers();
+        }
     }
 
     interface RunGet extends Run.Invoke

--- a/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
+++ b/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
@@ -1,5 +1,6 @@
 package com.github.mizool.core.concurrent;
 
+import java.time.Duration;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -20,16 +21,37 @@ public interface SynchronizerApi
         /**
          * Adds sleeping to the action chain. <br>
          * <br>
-         * When performing this action, the chain will sleep until another chain wakes it up, then call the given
-         * supplier. If the supplier returns {@code false}, this action chain resumes sleeping. Otherwise, the chain
-         * continues by performing the main action.
+         * When performing this action, the chain will ensure the given condition is met before performing the main
+         * action. If the supplier returns {@code false}, this action chain sleeps until another chain wakes it up.
+         * Then, the supplier is called again and if it still returns {@code false}, the chain resumes sleeping.
+         * Otherwise, the chain continues by performing the main action.
          *
          * @param state the supplier that returns {@code true} if the action chain should continue, {@code false}
          * otherwise.
          *
          * @throws NullPointerException if {@code state} is null
          */
-        RunGet sleepUntil(BooleanSupplier state);
+        default RunGet sleepUntil(BooleanSupplier state)
+        {
+            return sleepUntil(state, null);
+        }
+
+        /**
+         * Adds sleeping to the action chain. <br>
+         * <br>
+         * When performing this action, the chain will ensure the given condition is met before performing the main
+         * action. If the supplier returns {@code false}, this action chain sleeps until either another chain wakes it
+         * up or the timeout has passed. Then, the supplier is called again and if it still returns {@code false}, the
+         * chain resumes sleeping. Otherwise, the chain continues by performing the main action.
+         *
+         * @param state the supplier that returns {@code true} if the action chain should continue, {@code false}
+         * otherwise.
+         * @param timeout the maximum amount of time to sleep before re-checking the condition, or {@code null} to
+         * sleep indefinitely.
+         *
+         * @throws NullPointerException if {@code state} is null
+         */
+        RunGet sleepUntil(BooleanSupplier state, Duration timeout);
     }
 
     interface RunGet
@@ -64,7 +86,13 @@ public interface SynchronizerApi
         interface SleepInvoke extends Invoke, Base.SleepInvoke
         {
             @Override
-            Invoke thenSleepUntil(BooleanSupplier state);
+            default Invoke thenSleepUntil(BooleanSupplier state)
+            {
+                return thenSleepUntil(state, null);
+            }
+
+            @Override
+            Invoke thenSleepUntil(BooleanSupplier state, Duration timeout);
         }
 
         interface Invoke
@@ -108,7 +136,13 @@ public interface SynchronizerApi
         interface SleepInvoke<T> extends Invoke<T>, Base.SleepInvoke
         {
             @Override
-            Invoke<T> thenSleepUntil(BooleanSupplier state);
+            default Invoke<T> thenSleepUntil(BooleanSupplier state)
+            {
+                return thenSleepUntil(state, null);
+            }
+
+            @Override
+            Invoke<T> thenSleepUntil(BooleanSupplier state, Duration timeout);
         }
 
         interface Invoke<T>
@@ -146,18 +180,39 @@ public interface SynchronizerApi
         interface SleepInvoke
         {
             /**
-             * Adds sleeping to the end of the action chain. <br>
+             * Adds sleeping to the action chain. <br>
              * <br>
-             * When performing this action, the chain will sleep until another chain wakes it up, then call the given
-             * supplier. If the supplier returns {@code false}, this action chain resumes sleeping. Otherwise, the chain
-             * invocation finishes.
+             * When performing this action, the chain will ensure the given condition is met before returning. If the
+             * supplier returns {@code false}, this action chain sleeps until another chain wakes it up. Then, the
+             * supplier is called again and if it still returns {@code false}, the chain resumes sleeping. Otherwise,
+             * the chain invocation finishes.
              *
-             * @param state the supplier that returns {@code true} if the chain invocation should finish, {@code false}
+             * @param state the supplier that returns {@code true} if the action chain should finish, {@code false}
              * otherwise.
              *
              * @throws NullPointerException if {@code state} is null
              */
-            Object thenSleepUntil(BooleanSupplier state);
+            default Object thenSleepUntil(BooleanSupplier state)
+            {
+                return thenSleepUntil(state, null);
+            }
+
+            /**
+             * Adds sleeping to the action chain. <br>
+             * <br>
+             * When performing this action, the chain will ensure the given condition is met before returning. If the
+             * supplier returns {@code false}, this action chain sleeps until either another chain wakes it up or the
+             * timeout has passed. Then, the supplier is called again and if it still returns {@code false}, the chain
+             * resumes sleeping. Otherwise, the chain invocation finishes.
+             *
+             * @param state the supplier that returns {@code true} if the action chain should finish, {@code false}
+             * otherwise.
+             * @param timeout the maximum amount of time to sleep before re-checking the condition, or {@code null} to
+             * sleep indefinitely.
+             *
+             * @throws NullPointerException if {@code state} is null
+             */
+            Object thenSleepUntil(BooleanSupplier state, Duration timeout);
         }
     }
 }

--- a/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
+++ b/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
@@ -18,7 +18,7 @@ public interface SynchronizerApi
     {
     }
 
-    interface SleepRunGet extends Fluent, RunGet
+    interface SleepRunGet extends RunGet
     {
         /**
          * Adds sleeping to the action chain. <br>
@@ -86,7 +86,7 @@ public interface SynchronizerApi
         <T> Get.WakeSleepInvoke<T> get(Supplier<T> getter);
     }
 
-    interface RunGetInvoke extends Fluent, RunGet, Run.Invoke
+    interface RunGetInvoke extends RunGet, Run.Invoke
     {
         @Override
         default void invoke()
@@ -100,13 +100,13 @@ public interface SynchronizerApi
 
     interface Run
     {
-        interface WakeSleepInvoke extends Fluent, SleepInvoke, Base.WakeSleepInvoke
+        interface WakeSleepInvoke extends SleepInvoke, Base.WakeSleepInvoke
         {
             @Override
             SleepInvoke andWakeOthers();
         }
 
-        interface SleepInvoke extends Fluent, Invoke, Base.SleepInvoke
+        interface SleepInvoke extends Invoke, Base.SleepInvoke
         {
             @Override
             default Invoke thenSleepUntil(BooleanSupplier state)
@@ -140,7 +140,7 @@ public interface SynchronizerApi
 
     interface Get
     {
-        interface WakeSleepInvoke<T> extends Fluent, SleepInvoke<T>, Base.WakeSleepInvoke
+        interface WakeSleepInvoke<T> extends SleepInvoke<T>, Base.WakeSleepInvoke
         {
             @Override
             SleepInvoke<T> andWakeOthers();
@@ -156,7 +156,7 @@ public interface SynchronizerApi
             SleepInvoke<T> andWakeOthersIf(Predicate<T> predicate);
         }
 
-        interface SleepInvoke<T> extends Fluent, Invoke<T>, Base.SleepInvoke
+        interface SleepInvoke<T> extends Invoke<T>, Base.SleepInvoke
         {
             @Override
             default Invoke<T> thenSleepUntil(BooleanSupplier state)
@@ -193,7 +193,7 @@ public interface SynchronizerApi
 
     interface Base
     {
-        interface WakeSleepInvoke extends Fluent, SleepInvoke
+        interface WakeSleepInvoke extends SleepInvoke
         {
             /**
              * Adds an action which wakes other chains.

--- a/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
+++ b/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
@@ -54,7 +54,7 @@ public interface SynchronizerApi
         RunGet sleepUntil(BooleanSupplier state, Duration timeout);
     }
 
-    interface RunGet
+    interface RunGet extends Run.Invoke
     {
         /**
          * Sets the given {@link Runnable} as the main action of the chain.
@@ -73,6 +73,15 @@ public interface SynchronizerApi
          * @throws NullPointerException if {@code getter} is null
          */
         <T> Get.WakeSleepInvoke<T> get(Supplier<T> getter);
+
+        @Override
+        default void invoke()
+        {
+            Runnable noOp = () -> {
+            };
+
+            run(noOp).invoke();
+        }
     }
 
     interface Run

--- a/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
+++ b/core/src/main/java/com/github/mizool/core/concurrent/SynchronizerApi.java
@@ -5,12 +5,20 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.CheckReturnValue;
+
 /**
  * Provides fluent syntax for {@link Synchronizer}.
  */
 public interface SynchronizerApi
 {
-    interface SleepRunGet extends RunGet
+    @CheckReturnValue
+    interface Fluent
+    {
+    }
+
+    interface SleepRunGet extends Fluent, RunGet
     {
         /**
          * Adds sleeping to the action chain. <br>
@@ -57,7 +65,7 @@ public interface SynchronizerApi
         }
     }
 
-    interface RunGet
+    interface RunGet extends Fluent
     {
         /**
          * Sets the given {@link Runnable} as the main action of the chain.
@@ -78,7 +86,7 @@ public interface SynchronizerApi
         <T> Get.WakeSleepInvoke<T> get(Supplier<T> getter);
     }
 
-    interface RunGetInvoke extends RunGet, Run.Invoke
+    interface RunGetInvoke extends Fluent, RunGet, Run.Invoke
     {
         @Override
         default void invoke()
@@ -92,13 +100,13 @@ public interface SynchronizerApi
 
     interface Run
     {
-        interface WakeSleepInvoke extends SleepInvoke, Base.WakeSleepInvoke
+        interface WakeSleepInvoke extends Fluent, SleepInvoke, Base.WakeSleepInvoke
         {
             @Override
             SleepInvoke andWakeOthers();
         }
 
-        interface SleepInvoke extends Invoke, Base.SleepInvoke
+        interface SleepInvoke extends Fluent, Invoke, Base.SleepInvoke
         {
             @Override
             default Invoke thenSleepUntil(BooleanSupplier state)
@@ -110,7 +118,7 @@ public interface SynchronizerApi
             Invoke thenSleepUntil(BooleanSupplier state, Duration timeout);
         }
 
-        interface Invoke
+        interface Invoke extends Fluent
         {
             /**
              * Invokes the action chain in a synchronized block. <br>
@@ -132,7 +140,7 @@ public interface SynchronizerApi
 
     interface Get
     {
-        interface WakeSleepInvoke<T> extends SleepInvoke<T>, Base.WakeSleepInvoke
+        interface WakeSleepInvoke<T> extends Fluent, SleepInvoke<T>, Base.WakeSleepInvoke
         {
             @Override
             SleepInvoke<T> andWakeOthers();
@@ -148,7 +156,7 @@ public interface SynchronizerApi
             SleepInvoke<T> andWakeOthersIf(Predicate<T> predicate);
         }
 
-        interface SleepInvoke<T> extends Invoke<T>, Base.SleepInvoke
+        interface SleepInvoke<T> extends Fluent, Invoke<T>, Base.SleepInvoke
         {
             @Override
             default Invoke<T> thenSleepUntil(BooleanSupplier state)
@@ -160,7 +168,7 @@ public interface SynchronizerApi
             Invoke<T> thenSleepUntil(BooleanSupplier state, Duration timeout);
         }
 
-        interface Invoke<T>
+        interface Invoke<T> extends Fluent
         {
             /**
              * Invokes the action chain in a synchronized block. <br>
@@ -178,13 +186,14 @@ public interface SynchronizerApi
              * @throws com.github.mizool.core.exception.UncheckedInterruptedException if the thread was interrupted
              * while waiting (i.e. performing a sleep action).
              */
+            @CanIgnoreReturnValue
             T invoke();
         }
     }
 
     interface Base
     {
-        interface WakeSleepInvoke extends SleepInvoke
+        interface WakeSleepInvoke extends Fluent, SleepInvoke
         {
             /**
              * Adds an action which wakes other chains.
@@ -192,7 +201,7 @@ public interface SynchronizerApi
             Object andWakeOthers();
         }
 
-        interface SleepInvoke
+        interface SleepInvoke extends Fluent
         {
             /**
              * Adds sleeping to the action chain. <br>

--- a/core/src/main/java/com/github/mizool/core/concurrent/doc-files/synchronizer-railroad-diagram.svg
+++ b/core/src/main/java/com/github/mizool/core/concurrent/doc-files/synchronizer-railroad-diagram.svg
@@ -1,123 +1,145 @@
-<svg class="railroad-diagram" width="778" height="162" viewBox="0 0 778 162" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" width="844" height="208" viewBox="0 0 844 208" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <g transform="translate(.5 .5)">
         <g>
-            <path d="M20 41v20m10 -20v20m-10 -10h20"></path>
+            <path d="M20 49v20m10 -20v20m-10 -10h20"></path>
         </g>
         <g>
-            <path d="M40 51h0"></path>
-            <path d="M185 51h0"></path>
-            <path d="M40 51h20"></path>
+            <path d="M40 59h0"></path>
+            <path d="M716 59h0"></path>
+            <path d="M40 59h20"></path>
             <g>
-                <path d="M60 51h105"></path>
-            </g>
-            <path d="M165 51h20"></path>
-            <path d="M40 51a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
-            <g class="terminal ">
-                <path d="M60 71h0"></path>
-                <path d="M165 71h0"></path>
-                <rect x="60" y="60" width="105" height="22" rx="10" ry="10"></rect>
-                <text x="112.5" y="75">sleepUntil</text>
-            </g>
-            <path d="M165 71a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
-        </g>
-        <g>
-            <path d="M185 51h0"></path>
-            <path d="M468 51h0"></path>
-            <path d="M185 51h20"></path>
-            <g>
-                <path d="M205 51h8.5"></path>
-                <path d="M439.5 51h8.5"></path>
+                <path d="M60 59h0"></path>
+                <path d="M696 59h0"></path>
+                <path d="M60 59a10 10 0 0 0 10 -10v-19a10 10 0 0 1 10 -10h100a10 10 0 0 1 10 10v19a10 10 0 0 0 10 10"></path>
+                <path d="M60 59h20"></path>
                 <g class="non-terminal ">
-                    <path d="M213.5 51h0"></path>
-                    <path d="M259 51h0"></path>
-                    <rect x="213.5" y="40" width="45.5" height="22"></rect>
-                    <text x="236.25" y="55">run</text>
+                    <path d="M80 59h0"></path>
+                    <path d="M180 59h0"></path>
+                    <rect x="80" y="48" width="100" height="22"></rect>
+                    <text x="130" y="63">sleepUntil</text>
                 </g>
-                <path d="M259 51h10"></path>
+                <path d="M180 59h20"></path>
                 <g>
-                    <path d="M269 51h0"></path>
-                    <path d="M439.5 51h0"></path>
-                    <path d="M269 51a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
-                    <g class="non-terminal ">
-                        <path d="M289 31h0"></path>
-                        <path d="M419.5 31h0"></path>
-                        <rect x="289" y="20" width="130.5" height="22"></rect>
-                        <text x="354.25" y="35">andWakeOthers</text>
-                    </g>
-                    <path d="M419.5 31a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
-                    <path d="M269 51h20"></path>
+                    <path d="M200 59h0"></path>
+                    <path d="M686 59h0"></path>
+                    <path d="M200 59h20"></path>
                     <g>
-                        <path d="M289 51h130.5"></path>
+                        <path d="M220 59h0"></path>
+                        <path d="M666 59h0"></path>
+                        <g>
+                            <path d="M220 59h0"></path>
+                            <path d="M494 59h0"></path>
+                            <path d="M220 59h20"></path>
+                            <g>
+                                <path d="M240 59h8"></path>
+                                <path d="M466 59h8"></path>
+                                <g class="non-terminal ">
+                                    <path d="M248 59h0"></path>
+                                    <path d="M292 59h0"></path>
+                                    <rect x="248" y="48" width="44" height="22"></rect>
+                                    <text x="270" y="63">run</text>
+                                </g>
+                                <path d="M292 59h10"></path>
+                                <g>
+                                    <path d="M302 59h0"></path>
+                                    <path d="M466 59h0"></path>
+                                    <path d="M302 59a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
+                                    <g class="non-terminal ">
+                                        <path d="M322 39h0"></path>
+                                        <path d="M446 39h0"></path>
+                                        <rect x="322" y="28" width="124" height="22"></rect>
+                                        <text x="384" y="43">andWakeOthers</text>
+                                    </g>
+                                    <path d="M446 39a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
+                                    <path d="M302 59h20"></path>
+                                    <g>
+                                        <path d="M322 59h124"></path>
+                                    </g>
+                                    <path d="M446 59h20"></path>
+                                </g>
+                            </g>
+                            <path d="M474 59h20"></path>
+                            <path d="M220 59a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path>
+                            <g>
+                                <path d="M240 89h0"></path>
+                                <path d="M474 89h0"></path>
+                                <g class="non-terminal ">
+                                    <path d="M240 89h0"></path>
+                                    <path d="M284 89h0"></path>
+                                    <rect x="240" y="78" width="44" height="22"></rect>
+                                    <text x="262" y="93">get</text>
+                                </g>
+                                <path d="M284 89h10"></path>
+                                <g>
+                                    <path d="M294 89h0"></path>
+                                    <path d="M474 89h0"></path>
+                                    <path d="M294 89h20"></path>
+                                    <g>
+                                        <path d="M314 89h140"></path>
+                                    </g>
+                                    <path d="M454 89h20"></path>
+                                    <path d="M294 89a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
+                                    <g class="non-terminal ">
+                                        <path d="M314 109h8"></path>
+                                        <path d="M446 109h8"></path>
+                                        <rect x="322" y="98" width="124" height="22"></rect>
+                                        <text x="384" y="113">andWakeOthers</text>
+                                    </g>
+                                    <path d="M454 109a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
+                                    <path d="M294 89a10 10 0 0 1 10 10v30a10 10 0 0 0 10 10"></path>
+                                    <g class="non-terminal ">
+                                        <path d="M314 139h0"></path>
+                                        <path d="M454 139h0"></path>
+                                        <rect x="314" y="128" width="140" height="22"></rect>
+                                        <text x="384" y="143">andWakeOthersIf</text>
+                                    </g>
+                                    <path d="M454 139a10 10 0 0 0 10 -10v-30a10 10 0 0 1 10 -10"></path>
+                                </g>
+                            </g>
+                            <path d="M474 89a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path>
+                        </g>
+                        <g>
+                            <path d="M494 59h0"></path>
+                            <path d="M666 59h0"></path>
+                            <path d="M494 59a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
+                            <g class="non-terminal ">
+                                <path d="M514 39h0"></path>
+                                <path d="M646 39h0"></path>
+                                <rect x="514" y="28" width="132" height="22"></rect>
+                                <text x="580" y="43">thenSleepUntil</text>
+                            </g>
+                            <path d="M646 39a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
+                            <path d="M494 59h20"></path>
+                            <g>
+                                <path d="M514 59h132"></path>
+                            </g>
+                            <path d="M646 59h20"></path>
+                        </g>
                     </g>
-                    <path d="M419.5 51h20"></path>
+                    <path d="M666 59h20"></path>
                 </g>
+                <path d="M686 59h10"></path>
+                <path d="M180 59a10 10 0 0 1 10 10v79a10 10 0 0 0 10 10h476a10 10 0 0 0 10 -10v-79a10 10 0 0 1 10 -10"></path>
             </g>
-            <path d="M448 51h20"></path>
-            <path d="M185 51a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path>
-            <g>
-                <path d="M205 81h0"></path>
-                <path d="M448 81h0"></path>
-                <g class="non-terminal ">
-                    <path d="M205 81h0"></path>
-                    <path d="M250.5 81h0"></path>
-                    <rect x="205" y="70" width="45.5" height="22"></rect>
-                    <text x="227.75" y="85">get</text>
-                </g>
-                <path d="M250.5 81h10"></path>
-                <g>
-                    <path d="M260.5 81h0"></path>
-                    <path d="M448 81h0"></path>
-                    <path d="M260.5 81h20"></path>
-                    <g>
-                        <path d="M280.5 81h147.5"></path>
-                    </g>
-                    <path d="M428 81h20"></path>
-                    <path d="M260.5 81a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
-                    <g class="non-terminal ">
-                        <path d="M280.5 101h8.5"></path>
-                        <path d="M419.5 101h8.5"></path>
-                        <rect x="289" y="90" width="130.5" height="22"></rect>
-                        <text x="354.25" y="105">andWakeOthers</text>
-                    </g>
-                    <path d="M428 101a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
-                    <path d="M260.5 81a10 10 0 0 1 10 10v30a10 10 0 0 0 10 10"></path>
-                    <g class="non-terminal ">
-                        <path d="M280.5 131h0"></path>
-                        <path d="M428 131h0"></path>
-                        <rect x="280.5" y="120" width="147.5" height="22"></rect>
-                        <text x="354.25" y="135">andWakeOthersIf</text>
-                    </g>
-                    <path d="M428 131a10 10 0 0 0 10 -10v-30a10 10 0 0 1 10 -10"></path>
-                </g>
-            </g>
-            <path d="M448 81a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path>
-        </g>
-        <g>
-            <path d="M468 51h0"></path>
-            <path d="M647 51h0"></path>
-            <path d="M468 51a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
+            <path d="M696 59h20"></path>
+            <path d="M40 59a10 10 0 0 1 10 10v98a10 10 0 0 0 10 10"></path>
             <g class="non-terminal ">
-                <path d="M488 31h0"></path>
-                <path d="M627 31h0"></path>
-                <rect x="488" y="20" width="139" height="22"></rect>
-                <text x="557.5" y="35">thenSleepUntil</text>
+                <path d="M60 177h268"></path>
+                <path d="M428 177h268"></path>
+                <rect x="328" y="166" width="100" height="22"></rect>
+                <text x="378" y="181">wakeOthers</text>
             </g>
-            <path d="M627 31a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
-            <path d="M468 51h20"></path>
-            <g>
-                <path d="M488 51h139"></path>
-            </g>
-            <path d="M627 51h20"></path>
+            <path d="M696 177a10 10 0 0 0 10 -10v-98a10 10 0 0 1 10 -10"></path>
         </g>
-        <path d="M647 51h10"></path>
+        <path d="M716 59h10"></path>
         <g class="non-terminal ">
-            <path d="M657 51h0"></path>
-            <path d="M728 51h0"></path>
-            <rect x="657" y="40" width="71" height="22"></rect>
-            <text x="692.5" y="55">invoke</text>
+            <path d="M726 59h0"></path>
+            <path d="M794 59h0"></path>
+            <rect x="726" y="48" width="68" height="22"></rect>
+            <text x="760" y="63">invoke</text>
         </g>
-        <path d="M728 51h10"></path>
-        <path d="M 738 51 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+        <path d="M794 59h10"></path>
+        <path d="M 804 59 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
     </g>
     <style>
         svg {

--- a/core/src/main/java/com/github/mizool/core/concurrent/doc-files/synchronizer-railroad-diagram.txt
+++ b/core/src/main/java/com/github/mizool/core/concurrent/doc-files/synchronizer-railroad-diagram.txt
@@ -1,28 +1,37 @@
 Diagram(
-  Optional('sleepUntil', 'skip'),
-  Choice(0,
-    Sequence(
-      NonTerminal('run'),
-      Choice(
-        1,
-        NonTerminal('andWakeOthers'),
-        Skip(),
-      )
+    Choice(0,
+        OptionalSequence(
+            NonTerminal('sleepUntil'),
+            Choice(0,
+                Sequence(
+                    Choice(0,
+                        Sequence(
+                            NonTerminal('run'),
+                            Choice(
+                                1,
+                                NonTerminal('andWakeOthers'),
+                                Skip(),
+                            )
+                        ),
+                        Sequence(
+                            NonTerminal('get'),
+                            Choice(
+                                0,
+                                Skip(),
+                                NonTerminal('andWakeOthers', 'skip'),
+                                NonTerminal('andWakeOthersIf', 'skip')
+                            )
+                        ),
+                    ),
+                    Choice(
+                        1,
+                        NonTerminal('thenSleepUntil'),
+                        Skip(),
+                    ),
+                ),
+            ),
+        ),
+        NonTerminal('wakeOthers'),
     ),
-    Sequence(
-      NonTerminal('get'),
-      Choice(
-        0,
-        Skip(),
-        NonTerminal('andWakeOthers', 'skip'),
-        NonTerminal('andWakeOthersIf', 'skip')
-      )
-    ),
-  ),
-  Choice(
-    1,
-    NonTerminal('thenSleepUntil'),
-    Skip(),
-  ),
-  NonTerminal('invoke')
+    NonTerminal('invoke')
 )

--- a/core/src/test/java/com/github/mizool/core/concurrent/TestSynchronizer.java
+++ b/core/src/test/java/com/github/mizool/core/concurrent/TestSynchronizer.java
@@ -1,0 +1,473 @@
+package com.github.mizool.core.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+import org.assertj.core.api.SoftAssertions;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.util.Strings;
+
+public class TestSynchronizer
+{
+    private static final Predicate<Character> IS_LETTER = Character::isLetter;
+    private static final Predicate<Character> IS_DIGIT = Character::isDigit;
+
+    @RequiredArgsConstructor
+    @Builder
+    private static class Appender implements Runnable
+    {
+        private final Synchronizer synchronizer;
+        private final StringBuilder target;
+        private final int limit;
+        private final Predicate<Character> predicate;
+        private final char charToAppend;
+
+        @Override
+        public void run()
+        {
+            boolean keepRunning;
+            do
+            {
+                keepRunning = synchronizer.sleepUntil(this::shouldWake)
+                    .get(this::doAppend)
+                    .andWakeOthers()
+                    .invoke();
+            }
+            while (keepRunning);
+        }
+
+        private boolean shouldWake()
+        {
+            if (target.length() == 0)
+            {
+                return false;
+            }
+
+            if (target.length() >= limit)
+            {
+                return true;
+            }
+
+            char lastChar = target.charAt(target.length() - 1);
+            return predicate.test(lastChar);
+        }
+
+        private boolean doAppend()
+        {
+            if (target.length() >= limit)
+            {
+                // We're finished; let's end the loop in run().
+                return false;
+            }
+
+            target.append(charToAppend);
+            return true;
+        }
+    }
+
+    private Synchronizer synchronizer;
+
+    @BeforeMethod
+    private void setUp()
+    {
+        synchronizer = new Synchronizer();
+    }
+
+    @DataProvider
+    public static Object[][] pingPongVariants()
+    {
+        return new Object[][]{
+            new Object[]{ 'a', "ab" }, new Object[]{ 'b', "ba" }
+        };
+    }
+
+    /**
+     * Two threads where each appends its letter ('a' or 'b') after the other one did.
+     */
+    @Test(timeOut = 2000, dataProvider = "pingPongVariants")
+    public void testFairPingPong(char initialChar, String resultingPattern)
+    {
+        StringBuilder resultBuilder = new StringBuilder();
+
+        var appenders = List.of(Appender.builder()
+                .synchronizer(synchronizer)
+                .target(resultBuilder)
+                .limit(100)
+                .predicate(previous -> previous == 'b')
+                .charToAppend('a')
+                .build(),
+            Appender.builder()
+                .synchronizer(synchronizer)
+                .target(resultBuilder)
+                .limit(100)
+                .predicate(previous -> previous == 'a')
+                .charToAppend('b')
+                .build());
+
+        runAppenderTest(synchronizer, resultBuilder, appenders, initialChar);
+
+        String result = resultBuilder.toString();
+        assertThat(result).isEqualTo(Strings.repeat(resultingPattern, 50));
+    }
+
+    private void runAppenderTest(
+        Synchronizer synchronizer, StringBuilder target, List<Appender> appenders, char initialChar)
+    {
+        submitAndWaitForCompletion(() -> synchronizer.run(() -> target.append(initialChar))
+            .andWakeOthers()
+            .invoke(), appenders);
+    }
+
+    private void submitAndWaitForCompletion(Runnable initialAction, List<? extends Runnable> runnables)
+    {
+        CompletableFuture<Void> combinedFuture = submit(runnables);
+        initialAction.run();
+        Futures.get(combinedFuture);
+    }
+
+    public CompletableFuture<Void> submit(List<? extends Runnable> runnables)
+    {
+        ExecutorService executorService = Executors.newFixedThreadPool(runnables.size());
+
+        var completableFutures = runnables.stream()
+            .map(runnable -> CompletableFuture.runAsync(runnable, executorService))
+            .collect(Collectors.toList())
+            .toArray(new CompletableFuture<?>[]{});
+
+        return CompletableFuture.allOf(completableFutures);
+    }
+
+    @DataProvider
+    public static Object[][] unfairPingPongVariants()
+    {
+        return new Object[][]{
+            new Object[]{ 'a', 'a', 'b', "ab" },
+            new Object[]{ 'b', 'b', 'a', "ba" },
+            new Object[]{ 'a', 'b', 'a', "ab" },
+            new Object[]{ 'b', 'a', 'b', "ba" }
+        };
+    }
+
+    /**
+     * Like {@link #testFairPingPong(char, String)}, but with 50 threads appending the 'majority' char versus only one
+     * that appends the 'minority' char.
+     */
+    @Test(timeOut = 2000, dataProvider = "unfairPingPongVariants")
+    public void testUnfairPingPong(char initialChar, char majorityChar, char minorityChar, String resultingPattern)
+    {
+        StringBuilder resultBuilder = new StringBuilder();
+
+        List<Appender> appenders = new ArrayList<>();
+
+        for (int i = 0; i < 50; i++)
+        {
+            appenders.add(Appender.builder()
+                .synchronizer(synchronizer)
+                .target(resultBuilder)
+                .limit(100)
+                .predicate(previous -> previous != majorityChar)
+                .charToAppend(majorityChar)
+                .build());
+        }
+
+        appenders.add(Appender.builder()
+            .synchronizer(synchronizer)
+            .target(resultBuilder)
+            .limit(100)
+            .predicate(previous -> previous != minorityChar)
+            .charToAppend(minorityChar)
+            .build());
+
+        runAppenderTest(synchronizer, resultBuilder, appenders, initialChar);
+
+        String result = resultBuilder.toString();
+        assertThat(result).isEqualTo(Strings.repeat(resultingPattern, 50));
+    }
+
+    @DataProvider
+    public static Object[][] groupVariants()
+    {
+        return new Object[][]{
+            new Object[]{ 'a', "letter", "digit", IS_LETTER, IS_DIGIT },
+            new Object[]{ '1', "digit", "letter", IS_DIGIT, IS_LETTER },
+            };
+    }
+
+    /**
+     * Threads for each letter and for each digit together produce a string that strictly alternates between letters and
+     * digits.
+     */
+    @Test(timeOut = 2000, dataProvider = "groupVariants")
+    public void testTwoGroups(
+        char initialCharacter,
+        String firstKind,
+        String secondKind,
+        Predicate<Character> firstPredicate,
+        Predicate<Character> secondPredicate)
+    {
+        StringBuilder resultBuilder = new StringBuilder();
+
+        List<Appender> appenders = new ArrayList<>();
+
+        for (char letter : "abcdefghijklmnopqrstuvwxyz".toCharArray())
+        {
+            appenders.add(Appender.builder()
+                .synchronizer(synchronizer)
+                .target(resultBuilder)
+                .limit(100)
+                .predicate(Character::isDigit)
+                .charToAppend(letter)
+                .build());
+        }
+
+        for (char digit : "0123456789".toCharArray())
+        {
+            appenders.add(Appender.builder()
+                .synchronizer(synchronizer)
+                .target(resultBuilder)
+                .limit(100)
+                .predicate(Character::isLetter)
+                .charToAppend(digit)
+                .build());
+        }
+
+        runAppenderTest(synchronizer, resultBuilder, appenders, initialCharacter);
+
+        String result = resultBuilder.toString();
+        System.out.println(result);
+
+        // The characters in the string should strictly alternate between the two kinds of characters
+        assertSoftly(softly -> {
+            for (int i = 0; i < result.length(); i += 2)
+            {
+                softly.assertThat(result.charAt(i))
+                    .describedAs("char #%d in \"%s\"", i, result)
+                    .matches(firstPredicate, "is " + firstKind);
+
+                softly.assertThat(result.charAt(i + 1))
+                    .describedAs("char #%d in \"%s\"", i + 1, result)
+                    .matches(secondPredicate, "is " + secondKind);
+            }
+        });
+    }
+
+    @Test(timeOut = 2000)
+    public void testWakingAffectsAllThreads()
+    {
+        Set<Integer> integers = IntStream.range(0, 100)
+            .boxed()
+            .collect(Collectors.toSet());
+
+        Set<Integer> chainsThatWoke = new HashSet<>();
+
+        AtomicBoolean ready = new AtomicBoolean(false);
+
+        List<Runnable> runnables = integers.stream()
+            .map(value -> (Runnable) () -> synchronizer.sleepUntil(() -> {
+                    /*
+                     * As the condition is checked immediately when invoking the chain, we must return false to even
+                     * begin sleeping.
+                     */
+                    if (!ready.get())
+                    {
+                        return false;
+                    }
+
+                    // Track that this chain woke to check its condition
+                    chainsThatWoke.add(value);
+
+                    return true;
+                })
+                .invoke())
+            .collect(Collectors.toList());
+
+        submitAndWaitForCompletion(() -> {
+            ready.set(true);
+            synchronizer.wakeOthers()
+                .invoke();
+        }, runnables);
+
+        assertThat(chainsThatWoke).isEqualTo(integers);
+    }
+
+    @Test(timeOut = 2000)
+    public void testFailingConditionPreventsMainAction()
+    {
+        AtomicBoolean conditionChecked = new AtomicBoolean(false);
+
+        submit(() -> synchronizer.sleepUntil(() -> {
+                // Track that this chain woke to check its condition
+                conditionChecked.set(true);
+
+                return false;
+            })
+            .run(() -> fail("Main action is not supposed to run when condition is false"))
+            .invoke());
+
+        synchronizer.wakeOthers()
+            .invoke();
+
+        Threads.sleep(200);
+
+        assertThat(conditionChecked).isTrue();
+    }
+
+    private CompletableFuture<Void> submit(Runnable... runnables)
+    {
+        return submit(Arrays.asList(runnables));
+    }
+
+    @Test(timeOut = 2000)
+    public void testConditionCheckedInitially()
+    {
+        AtomicBoolean conditionChecked = new AtomicBoolean(false);
+
+        CompletableFuture<Void> future = submit(() -> synchronizer.sleepUntil(() -> {
+                conditionChecked.set(true);
+                return true;
+            })
+            .invoke());
+
+        Futures.get(future, Duration.ofMillis(200));
+
+        // Condition was checked even though no wake call happened
+        assertThat(conditionChecked).isTrue();
+    }
+
+    @Test(timeOut = 2000)
+    public void testConditionCheckInterval()
+    {
+        AtomicInteger conditionCheckCount = new AtomicInteger();
+        AtomicBoolean finishing = new AtomicBoolean(false);
+
+        Duration interval = Duration.ofMillis(200);
+        int intervalCount = 2;
+
+        CompletableFuture<Void> future = submit(() -> synchronizer.sleepUntil(() -> {
+                conditionCheckCount.incrementAndGet();
+                return finishing.get();
+            }, interval)
+            .invoke());
+
+        Threads.sleep((long) (interval.toMillis() * (intervalCount + 0.5)));
+
+        finishing.set(true);
+        synchronizer.wakeOthers()
+            .invoke();
+
+        Futures.get(future, interval.dividedBy(4));
+
+        /*
+         * In addition to the interval count, there is one check shortly after invoking the chain and another one due to
+         * the finishing wakeOthers() call.
+         */
+        assertThat(conditionCheckCount).hasValue(intervalCount + 2);
+    }
+
+    @Test(timeOut = 2000)
+    public void testConditionallyWakingOthers()
+    {
+        AtomicBoolean ready = new AtomicBoolean(false);
+        AtomicBoolean firstCompleted = new AtomicBoolean(false);
+        AtomicBoolean secondCompleted = new AtomicBoolean(false);
+
+        Runnable first = () -> synchronizer.sleepUntil(ready::get)
+            .get(() -> {
+                firstCompleted.set(true);
+                return "indeed";
+            })
+            .andWakeOthersIf(s -> s.equals("indeed"))
+            .invoke();
+
+        Runnable second = () -> synchronizer.sleepUntil(() -> ready.get() && firstCompleted.get())
+            .run(() -> secondCompleted.set(true))
+            .invoke();
+
+        submitAndWaitForCompletion(() -> {
+            ready.set(true);
+            synchronizer.wakeOthers()
+                .invoke();
+        }, first, second);
+
+        assertThat(secondCompleted).isTrue();
+    }
+
+    private void submitAndWaitForCompletion(Runnable initialAction, Runnable... runnables)
+    {
+        submitAndWaitForCompletion(initialAction, Arrays.asList(runnables));
+    }
+
+    @Test(timeOut = 2000)
+    public void testConditionallyNotWakingOthers()
+    {
+        AtomicBoolean ready = new AtomicBoolean(false);
+        AtomicBoolean firstCompleted = new AtomicBoolean(false);
+        AtomicBoolean firstWokeSecond = new AtomicBoolean(false);
+
+        Runnable first = () -> synchronizer.sleepUntil(ready::get)
+            .get(() -> {
+                firstCompleted.set(true);
+                return "nope";
+            })
+            .andWakeOthersIf(s -> s.equals("indeed"))
+            .invoke();
+
+        Runnable second = () -> synchronizer.sleepUntil(() -> {
+                if (!ready.get())
+                {
+                    return false;
+                }
+
+                if (firstCompleted.get())
+                {
+                    // Track that the test has failed. [`throw` would be useless as nobody uses our Future.get()]
+                    firstWokeSecond.set(true);
+                    return true;
+                }
+
+                return false;
+            })
+            .invoke();
+
+        // Submit both chain threads, but keep only the first future as the second is not supposed to complete anyway.
+        CompletableFuture<Void> firstFuture = submit(first);
+        submit(second);
+
+        ready.set(true);
+        synchronizer.wakeOthers()
+            .invoke();
+
+        Futures.get(firstFuture);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(firstCompleted)
+                .describedAs("first chain main action completed")
+                .isTrue();
+
+            softly.assertThat(firstWokeSecond)
+                .describedAs("first chain woke second")
+                .isFalse();
+        });
+    }
+}


### PR DESCRIPTION
### Motivation & background

Extend the Synchronizer API for usage scenarios where there is no specific "handover" by another thread that wakes up the synchronizer chains. One example is implementing scheduled polling that _can_, but _does not have to_ be quickened by explicit wake calls.

The code should be stable enough as it has been in production use for a while now.

### New features

1. Ability to specify an interval for sleeping after which the condition is checked again even when no wake call happens.
2. Allow sleeping as the sole action of a synchronizer chain.
3. Allow waking others as the sole action of a synchronizer chain.

In the diagram below, features 2 and 3 are highlighted (the updated diagram for Javadoc includes them but without highlighting):

![synchronizer-api-change-illustration](https://user-images.githubusercontent.com/3303967/228612478-2ce5ea02-1e8d-4714-a425-e4ad01d0de01.png)

### Other improvements

Additionally, this PR enables IntelliJ IDEA to complain when one forgets the final `invoke()` on a method chain of the fluent API:
``` java
synchronizer.sleepUntil(...)
    .run(...)
    .andWakeOthers(); // <- IDE warning: "Result of 'Synchronizer.andWakeOthers()' is ignored"
```

``` java
synchronizer.sleepUntil(...)
    .run(...)
    .andWakeOthers() // <- No warning now.
    .invoke();
```

Furthermore, javadocs are vastly improved.

Lastly, we now have isolated unit tests instead of only testing `Synchronizer` indirectly via `BufferedStreamAdapter`.


### Review hints

Reading the individual commits instead of the entire PR is recommended, starting with 7b5b92f894042a72c507c517e58a783136927286 "Add support for sleep timeout".